### PR TITLE
Feat/bad dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,3 @@
 FROM hello-world
+
+ENTRYPOINT [ "/sbin/init" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM hello-world
 
-ENTRYPOINT [ "/sbin/init" ]
+RUN ls /path/does/not/exists


### PR DESCRIPTION
在 docker build 時加入對不存在之檔案、資料夾的存取導致 build 崩潰。

```diff
# In Dockerfile
RUN ls /path/does/not/exists
```

build 失敗之 Github Action 連結：
https://github.com/Shiritai/2025cloud/actions/runs/14829290927

